### PR TITLE
Added queue statistics

### DIFF
--- a/ngQueue.js
+++ b/ngQueue.js
@@ -85,7 +85,7 @@ function ($q,   $window,   $timeout,   $rootScope, $filter) {
         todo = buf[0],
         context = buf[1],
         args = buf[2],
-        success, error;
+        success, error, always;
 
     p._list.push({id:timestamp,resolved:false});
 
@@ -101,7 +101,7 @@ function ($q,   $window,   $timeout,   $rootScope, $filter) {
       else {
         p.dequeue();
       }
-    },
+    };
     always = function () {
       
       var item = $filter('filter')(p._list, {id:timestamp})[0];
@@ -111,8 +111,10 @@ function ($q,   $window,   $timeout,   $rootScope, $filter) {
 
     };
 
+    /*jshint es5: true */
     $q.when(todo.apply(context || null, args || null))
     .then(success, error).finally(always);
+    /*jshint es5: false */
   };
 
   p.clear = function () {

--- a/ngQueue.js
+++ b/ngQueue.js
@@ -88,7 +88,7 @@ function ($q,   $window,   $timeout,   $rootScope, $filter) {
     p._limit--;
 
     var buf = p._queue.shift(),
-        timestamp = new Date().getTime(),
+        timestamp = Math.random(),
         todo = buf[0],
         context = buf[1],
         args = buf[2],

--- a/ngQueue.js
+++ b/ngQueue.js
@@ -16,14 +16,14 @@ function ($q,   $window,   $timeout,   $rootScope) {
   p._limit = null;
 
   // the queue
-  p._queue = null;
+  p._queue = [];
 
   // function used for deferring
   p._deferFunc = null;
 
   p.init = function (config) {
-    this._limit = config.limit;
-    this._queue = [];
+    p._limit = config.limit;
+    p._queue = [];
 
     if (config.deferred) {
       if ($window.setImmediate) {
@@ -46,41 +46,42 @@ function ($q,   $window,   $timeout,   $rootScope) {
   p.enqueue = function (todo, context, args) {
     var task = [todo, context, args];
 
-    this._queue.push([todo, context, args]);
+    p._queue.push([todo, context, args]);
 
-    this.dequeue();
+    p.dequeue();
     return task;
   };
 
   p.remove = function (task) {
-    var index = this._queue.indexOf(task);
-    return this._queue.splice(index, 1)[0];
+    var index = p._queue.indexOf(task),
+    item = p._queue.splice(index, 1)[0];
+    return item;
   };
 
   p.dequeue = function () {
-    if (this._limit <= 0 || this._queue.length === 0) {
+    if (p._limit <= 0 || p._queue.length === 0) {
       return;
     }
 
-    this._limit--;
+    p._limit--;
 
-    var buf = this._queue.shift(),
+    var buf = p._queue.shift(),
         todo = buf[0],
         context = buf[1],
         args = buf[2],
         success, error;
 
-    var that = this;
     success = error = function () {
-      that._limit++;
+      p._limit++;
 
-      if (that._deferFunc) {
-        that._deferFunc(function () {
-          that.dequeue();
+
+      if (p._deferFunc) {
+        p._deferFunc(function () {
+          p.dequeue();
         });
       }
       else {
-        that.dequeue();
+        p.dequeue();
       }
     };
 
@@ -89,7 +90,7 @@ function ($q,   $window,   $timeout,   $rootScope) {
   };
 
   p.clear = function () {
-    this._queue.length = 0;
+    p._queue = [];
   };
 
   return function factory(limit, deferred) {

--- a/ngQueue.js
+++ b/ngQueue.js
@@ -17,6 +17,8 @@ function ($q,   $window,   $timeout,   $rootScope, $filter) {
     p.queueIdle = p.queuePending < 1;
   };
 
+  p._config = {};
+
   // number of simultaneously runnable tasks
   p._limit = null;
 
@@ -34,6 +36,7 @@ function ($q,   $window,   $timeout,   $rootScope, $filter) {
 
 
   p.init = function (config) {
+    p._config = config;
     p._limit = config.limit;
     p._queue = [];
 
@@ -60,7 +63,9 @@ function ($q,   $window,   $timeout,   $rootScope, $filter) {
 
     p._queue.push([todo, context, args]);
 
-    updateStats();
+    if (p._config.statistics) {
+      updateStats();
+    }
 
     p.dequeue();
     return task;
@@ -69,7 +74,9 @@ function ($q,   $window,   $timeout,   $rootScope, $filter) {
   p.remove = function (task) {
     var index = p._queue.indexOf(task),
     item = p._queue.splice(index, 1)[0];
-    updateStats();
+    if (p._config.statistics) {
+      updateStats();
+    }
     return item;
   };
 
@@ -87,7 +94,9 @@ function ($q,   $window,   $timeout,   $rootScope, $filter) {
         args = buf[2],
         success, error, always;
 
-    p._list.push({id:timestamp,resolved:false});
+    if (p._config.statistics) {
+      p._list.push({id:timestamp,resolved:false});
+    }
 
     success = error = function () {
       p._limit++;
@@ -103,11 +112,13 @@ function ($q,   $window,   $timeout,   $rootScope, $filter) {
       }
     };
     always = function () {
-      
-      var item = $filter('filter')(p._list, {id:timestamp})[0];
-      item.resolved = true;
 
-      updateStats();
+      if (p._config.statistics) {
+        var item = $filter('filter')(p._list, {id:timestamp})[0];
+        item.resolved = true;
+
+        updateStats();
+      }
 
     };
 
@@ -120,7 +131,9 @@ function ($q,   $window,   $timeout,   $rootScope, $filter) {
   p.clear = function () {
     p._queue = [];
     p._list = [];
-    updateStats();
+    if (p._config.statistics) {
+      updateStats();
+    }
   };
 
   return function factory(limit, deferred) {


### PR DESCRIPTION
Hi,

I really like your package. For a new project I needed a bit more details about the queue, therefor I've added some statistics:
* Total items in the queue (All (un)resolved items + items still in _queue list)
* Total items that are pending (all unresolved items + items still in _queue list)
* Boolean that will be true when all items in the queue are resolved

The statistics are accessible like this:
```js
var queue1 = $queueFactory(2);
console.log(queue1.queueTotal, queue1.queuePending, queue1.queueIdle);
```

I'm using this for a progress bar...